### PR TITLE
Removed duplicate rows in metadata.csv

### DIFF
--- a/metadata.csv
+++ b/metadata.csv
@@ -721,17 +721,6 @@ SEARCH-1115-SAN,,EPI_ISL_483538,2020-06-23,USA/California/San Diego,100,18862.1,
 SEARCH-1116-SAN,,EPI_ISL_483539,2020-06-18,USA/California/San Diego,100,19709.8,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
 SEARCH-1117-SAN,,EPI_ISL_483540,2020-06-23,USA/California/San Diego,100,18179.2,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
 SEARCH-1118-SAN,,EPI_ISL_483541,2020-06-21,USA/California/San Diego,100,21560.5,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1107-SAN,,,2020-06-25,USA/California/San Diego,100,3253.6,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1108-SAN,,,2020-06-25,USA/California/San Diego,100,11780,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1110-SAN,,,2020-06-18,USA/California/San Diego,100,7507.25,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1111-SAN,,,2020-06-21,USA/California/San Diego,100,12218.1,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1112-SAN,,,2020-06-22,USA/California/San Diego,100,29880.7,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1113-SAN,,,2020-06-23,USA/California/San Diego,100,27901.9,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1114-SAN,,,2020-06-25,USA/California/San Diego,100,20843.8,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1115-SAN,,,2020-06-23,USA/California/San Diego,100,18862.1,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1116-SAN,,,2020-06-18,USA/California/San Diego,100,19709.8,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1117-SAN,,,2020-06-23,USA/California/San Diego,100,18179.2,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
-SEARCH-1118-SAN,,,2020-06-21,USA/California/San Diego,100,21560.5,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
 SEARCH-1119-CS2,,,2020-04-03,USA/California/Cruise_Ship_2,100,21965.5,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
 SEARCH-1120-CS2,,,2020-04-03,USA/California/Cruise_Ship_2,100,23154.9,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory
 SEARCH-1121-CS2,,,2020-04-03,USA/California/Cruise_Ship_2,100,7737.8,"SEARCH Alliance San Diego with Tracy Basler, Jovan Shephard, Brett Austin",San Diego County Public Health Laboratory


### PR DESCRIPTION
Samples SEARCH-1107-1118 had two entries in metadata.csv. The second occurrence of each entry lacked GISAID accession numbers, so I removed those.