### PR TITLE
Readme update automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,118 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Other file
+.DS_Store
+OLD_README.md

--- a/README.md
+++ b/README.md
@@ -3,93 +3,96 @@
 All consensus sequences will be deposited on GISAID and on NCBI under BioProject ID [PRJNA612578](https://www.ncbi.nlm.nih.gov/bioproject/612578).
 [metadata.csv](https://raw.githubusercontent.com/andersen-lab/HCoV-19-Genomics/master/metadata.csv) contains collection dates, location, originating labs and sequencing metrics: coverage and average depth.
 
-| Location                         | Number of sequences |
-|:---------------------------------|:--------------------|
-| Jordan/Amman                     | 483                 |
-| Jordan/Aqaba                     | 41                  |
-| Jordan/Irbid                     | 58                  |
-| Jordan/Mafraq                    | 2                   |
-| Jordan/Zarqa                     | 5                   |
-| MEX/Baja California		   | 26                  |
-| MEX/Baja California/Ensenada     | 16                  |
-| MEX/Baja California/Mexicali     | 258                 |
-| MEX/Baja California/Rosarito     | 1                   |
-| MEX/Baja California/Tecate       | 7			 |
-| MEX/Baja California/Tijuana      | 859                 |
-| MEX/Chihuahua                    | 9                   |
-| MEX/Chihuahua/Chihuahua          | 3                   |
-| MEX/Chihuahua/Ciudad Juarez      | 2                   |
-| MEX/Jalisco/Vallarta		   | 5			 |
-| MEX/Sinaloa/Los Mochis           | 10                  |
-| MEX/Sinaloa/Mazatlan             | 6                   |
-| MEX/Sonora                       | 32                  |
-| MEX/Sonora/Hermosillo            | 12                  |
-| MEX/Sonora/Obregon               | 10                  |
-| MEX/Sonora/San Luis Río Colorado | 35                  |
-| USA/Alaska/Anchorage		   | 1			 |
-| USA/Arizona/Maricopa	           | 2                   |
-| USA/Arizona/Pima                 | 2                   |
-| USA/Arizona/Yuma                 | 1                   |
-| USA/California/Alameda           | 2                   |
-| USA/California/Contra Costa      | 3                   |
-| USA/California/Cruise_Ship_1     | 8                   |
-| USA/California/Cruise_Ship_2     | 32                  |
-| USA/California/Davis             | 1                   |
-| USA/California/El Dorado         | 4			 |
-| USA/California/Fresno		   | 1			 |
-| USA/California/Imperial          | 154                 |
-| USA/California/Kern              | 2                   |
-| USA/California/Los Angeles       | 136                 |
-| USA/California/Marin             | 1                   |
-| USA/California/Modesto           | 1			 |
-| USA/California/Monterey          | 1                   |
-| USA/California/Orange            | 32                  |
-| USA/California/Placer            | 1                   |
-| USA/California/Riverside         | 126                 |
-| USA/California/Sacramento        | 2                   |
-| USA/California/San Bernadino     | 9                   |
-| USA/California/San Diego         | 17903               |
-| USA/California/San Francisco     | 1                   |
-| USA/California/San Mateo	   | 1			 |
-| USA/California/Santa Barbara     | 4                   |
-| USA/California/Santa Clara       | 3                   |
-| USA/California/Sonoma            | 1                   |
-| USA/California/Sutter            | 1                   |
-| USA/California/Tulare            | 1                   |
-| USA/California/Ventura           | 3                   |
-| USA/Florida/Saint Johns	   | 1			 |
-| USA/Hawaii/Honolulu		   | 1                   |
-| USA/Idaho/Ada                    | 1                   | 
-| USA/Illinois/Cook                | 2                   | 
-| USA/Illinois/DuPage              | 2                   | 
-| USA/Illinois/Rock Island         | 1                   |
-| USA/Kentucky/Jefferson           | 1                   | 
-| USA/Louisiana/New Orleans        | 143                 | 
-| USA/Maryland/Anne Arundel        | 1                   | 
-| USA/Michigan/Wayne               | 1                   | 
-| USA/Minnesota/Anoka              | 1                   | 
-| USA/Minnesota/Ramsey             | 1                   | 
-| USA/Nevada/Clark                 | 1                   |
-| USA/Nevada/Douglas               | 1                   |
-| USA/New Jersey/Monmouth          | 1                   |
-| USA/New York/Orange              | 1                   | 
-| USA/New York/Warren              | 1                   | 
-| USA/New York/Westchester         | 1                   | 
-| USA/North Carolina/Durham        | 1                   |
-| USA/Ohio/Clark                   | 1                   | 
-| USA/Ohio/Hamilton                | 1                   | 
-| USA/Oklahoma/Tulsa               | 1                   | 
-| USA/Pennsylvania/Allegheny       | 1                   | 
-| USA/Tennessee/Grainger           | 1                   | 
-| USA/Tennessee/Sumner             | 1                   | 
-| USA/Texas/Bell                   | 1                   | 
-| USA/Texas/Montgomery             | 2                   | 
-| USA/Utah/Salt Lake               | 1                   | 
-| USA/Washington/King              | 3                   | 
-| USA/Washington/Kitsap            | 1                   | 
-| USA/West Virginia/Kanawha        | 1                   | 
-| USA/Wisconsin/Bayfield           | 1                   |
-| USA/Wyoming/Albany               | 1                   | 
+| Location                         |   Number of Sequences |
+|:---------------------------------|----------------------:|
+| Jordan/Amman                     |                   483 |
+| Jordan/Aqaba                     |                    41 |
+| Jordan/Irbid                     |                    58 |
+| Jordan/Mafraq                    |                     2 |
+| Jordan/Zarqa                     |                     5 |
+| MEX/Baja California              |                    26 |
+| MEX/Baja California/Ensenada     |                    16 |
+| MEX/Baja California/Mexicali     |                   258 |
+| MEX/Baja California/Rosarito     |                     1 |
+| MEX/Baja California/Tecate       |                     7 |
+| MEX/Baja California/Tijuana      |                   859 |
+| MEX/Chihuahua                    |                     9 |
+| MEX/Chihuahua/Chihuahua          |                     3 |
+| MEX/Chihuahua/Ciudad Juarez      |                     2 |
+| MEX/Jalisco/Vallarta             |                     5 |
+| MEX/Sinaloa/Los Mochis           |                    16 |
+| MEX/Sonora                       |                    32 |
+| MEX/Sonora/Hermosillo            |                    12 |
+| MEX/Sonora/Obregon               |                    10 |
+| MEX/Sonora/San Luis Río Colorado |                    33 |
+| USA/Alaska/Anchorage             |                     1 |
+| USA/Arizona/Maricopa             |                     2 |
+| USA/Arizona/Pima                 |                     2 |
+| USA/Arizona/Yuma                 |                     1 |
+| USA/California/Alameda           |                     2 |
+| USA/California/Contra Costa      |                     3 |
+| USA/California/Cruise_Ship_1     |                     8 |
+| USA/California/Cruise_Ship_2     |                    32 |
+| USA/California/Davis             |                     1 |
+| USA/California/El Dorado         |                     4 |
+| USA/California/Fresno            |                     1 |
+| USA/California/Imperial          |                   154 |
+| USA/California/Kern              |                     2 |
+| USA/California/Los Angeles       |                   136 |
+| USA/California/Marin             |                     1 |
+| USA/California/Modesto           |                     1 |
+| USA/California/Monterey          |                     1 |
+| USA/California/Orange            |                    32 |
+| USA/California/Orange County     |                     1 |
+| USA/California/Placer            |                     1 |
+| USA/California/Riverside         |                   126 |
+| USA/California/Sacramento        |                     2 |
+| USA/California/San Bernardino    |                     9 |
+| USA/California/San Diego         |                 17903 |
+| USA/California/San Francisco     |                     1 |
+| USA/California/San Mateo         |                     1 |
+| USA/California/Santa Barbara     |                     3 |
+| USA/California/Santa Barbara     |                     1 |
+| USA/California/Santa Clara       |                     3 |
+| USA/California/Sonoma            |                     1 |
+| USA/California/Sutter            |                     1 |
+| USA/California/Tulare            |                     1 |
+| USA/California/Ventura           |                     3 |
+| USA/Florida/Saint Johns          |                     1 |
+| USA/Hawaii/Honolulu              |                     1 |
+| USA/Idaho/Ada                    |                     1 |
+| USA/Illinois/Cook                |                     2 |
+| USA/Illinois/DuPage              |                     2 |
+| USA/Illinois/Rock Island         |                     1 |
+| USA/Kentucky/Jefferson           |                     1 |
+| USA/Louisiana/New Orleans        |                   143 |
+| USA/Maryland/Anne Arundel        |                     1 |
+| USA/Maryland/Montgomery          |                     1 |
+| USA/Michigan/Wayne               |                     1 |
+| USA/Minnesota/Anoka              |                     1 |
+| USA/Minnesota/Ramsey             |                     1 |
+| USA/Nevada/Clark                 |                     1 |
+| USA/Nevada/Douglas               |                     1 |
+| USA/New Jersey/Monmouth          |                     1 |
+| USA/New York/Orange              |                     1 |
+| USA/New York/Warren              |                     1 |
+| USA/New York/Westchester         |                     1 |
+| USA/North Carolina/Durham        |                     1 |
+| USA/Ohio/Clark                   |                     1 |
+| USA/Ohio/Hamilton                |                     1 |
+| USA/Oklahoma/Tulsa               |                     1 |
+| USA/Pennsylvania/Allegheny       |                     1 |
+| USA/Tennessee/Grainger           |                     1 |
+| USA/Tennessee/Sumner             |                     1 |
+| USA/Texas/Bell                   |                     1 |
+| USA/Texas/Montgomery             |                     2 |
+| USA/Utah/Salt Lake               |                     1 |
+| USA/Virginia/Fairfax             |                     1 |
+| USA/Washington/King              |                     3 |
+| USA/Washington/Kitsap            |                     1 |
+| USA/West Virginia/Kanawha        |                     1 |
+| USA/Wisconsin/Bayfield           |                     1 |
+| USA/Wyoming/Albany               |                     1 |
 
 #### Raw read files
 

--- a/location_consolidation_mapping.csv
+++ b/location_consolidation_mapping.csv
@@ -1,0 +1,92 @@
+﻿raw_location,corrected_location
+Jordan/Amman,Jordan/Amman
+Jordan/Aqaba,Jordan/Aqaba
+Jordan/Irbid,Jordan/Irbid
+Jordan/Mafraq,Jordan/Mafraq
+Jordan/Zarqa,Jordan/Zarqa
+Mexico/Baja California/Ensenada,MEX/Baja California/Ensenada
+Mexico/Baja California/Mexicali,MEX/Baja California/Mexicali
+Mexico/Baja California/Rosarito,MEX/Baja California/Rosarito
+Mexico/Baja California/Tijuana,MEX/Baja California/Tijuana
+Mexico/Sonora/San Luis R√≠o Colorado,MEX/Sonora/San Luis Río Colorado
+USA/Arizona/Yuma,USA/Arizona/Yuma
+USA/California/Cruise_Ship_1,USA/California/Cruise_Ship_1
+USA/California/Cruise_Ship_2,USA/California/Cruise_Ship_2
+USA/California/Davis,USA/California/Davis
+USA/California/Imperial,USA/California/Imperial
+USA/California/Kern,USA/California/Kern
+USA/California/Los Angeles,USA/California/Los Angeles
+USA/California/Modesto,USA/California/Modesto
+USA/California/Orange,USA/California/Orange
+USA/California/Riverside,USA/California/Riverside
+USA/California/Sacramento,USA/California/Sacramento
+USA/California/San Bernardino,USA/California/San Bernardino
+USA/California/San Diego,USA/California/San Diego
+USA/California/Santa Barbara,USA/California/Santa Barbara
+USA/California/Santa Barbara ,USA/California/Santa Barbara 
+USA/California/Santa Clara,USA/California/Santa Clara
+USA/California/Sonoma,USA/California/Sonoma
+USA/California/Sutter,USA/California/Sutter
+USA/California/Ventura,USA/California/Ventura
+USA/Louisiana/New Orleans,USA/Louisiana/New Orleans
+USA/Minnesota/Ramsey,USA/Minnesota/Ramsey
+USA/Oklahoma/Tulsa,USA/Oklahoma/Tulsa
+USA/Tennessee/Grainger,USA/Tennessee/Grainger
+USA/Washington/King,USA/Washington/King
+USA/Washington/Kitsap,USA/Washington/Kitsap
+USA/West Virginia/Kanawha,USA/West Virginia/Kanawha
+USA/Illinois/DuPage,USA/Illinois/DuPage
+USA/California/Contra Costa,USA/California/Contra Costa
+USA/Illinois/Rock Island,USA/Illinois/Rock Island
+USA/Ohio/Hamilton,USA/Ohio/Hamilton
+USA/Texas/Montgomery,USA/Texas/Montgomery
+Mexico/Sonora/San Luis Rio Colorado,MEX/Sonora/San Luis Río Colorado
+Mexico/Baja California/Tecate,MEX/Baja California/Tecate
+USA/California/Los Angeles County,USA/California/Los Angeles County
+USA/California/El Dorado,USA/California/El Dorado
+USA/California/Fresno,USA/California/Fresno
+USA/Alaska/Anchorage Municipality,USA/Alaska/Anchorage
+USA/Utah/Salt Lake,USA/Utah/Salt Lake
+USA/Pennsylvania/Allegheny,USA/Pennsylvania/Allegheny
+USA/California/San Mateo,USA/California/San Mateo
+USA/Wyoming/Albany,USA/Wyoming/Albany
+Mexico/Baja California,MEX/Baja California
+Mexico/Sonora,MEX/Sonora
+Mexico/Chihuahua,MEX/Chihuahua
+USA/Arizona/Pima,USA/Arizona/Pima
+USA/Idaho/Ada,USA/Idaho/Ada
+USA/Florida/Saint Johns,USA/Florida/Saint Johns
+USA/Michigan/Wayne,USA/Michigan/Wayne
+USA/New York/Westchester,USA/New York/Westchester
+USA/Maryland/Anne Arundel,USA/Maryland/Anne Arundel
+USA/Nevada/Clark,USA/Nevada/Clark
+USA/Tennessee/Sumner,USA/Tennessee/Sumner
+USA/California/City and County of San Francisco,USA/California/San Francisco
+USA/Minnesota/Anoka,USA/Minnesota/Anoka
+USA/California/Alameda,USA/California/Alameda
+USA/California/Monterey,USA/California/Monterey
+USA/Hawaii/Honolulu,USA/Hawaii/Honolulu
+USA/Ohio/Clark,USA/Ohio/Clark
+USA/New York/Warren,USA/New York/Warren
+USA/Texas/Bell,USA/Texas/Bell
+USA/Arizona/Maricopa,USA/Arizona/Maricopa
+USA/Illinois/Cook,USA/Illinois/Cook
+USA/New York/Orange,USA/New York/Orange
+USA/California/Orange County,USA/California/Orange County
+USA/Maryland/Montgomery,USA/Maryland/Montgomery
+USA/North Carolina/Durham,USA/North Carolina/Durham
+USA/California/Placer,USA/California/Placer
+USA/California/Marin,USA/California/Marin
+USA/Kentucky/Jefferson,USA/Kentucky/Jefferson
+USA/Nevada/Douglas,USA/Nevada/Douglas
+USA/New Jersey/Monmouth,USA/New Jersey/Monmouth
+USA/Virginia/Fairfax,USA/Virginia/Fairfax
+USA/Wisconsin/Bayfield,USA/Wisconsin/Bayfield
+USA/California/Tulare,USA/California/Tulare
+Mexico/Sonora/Obregon,MEX/Sonora/Obregon
+Mexico/Chihuahua/Chihuahua,MEX/Chihuahua/Chihuahua
+Mexico/Sonora/Hermosillo,MEX/Sonora/Hermosillo
+Mexico/Jalisco/Vallarta,MEX/Jalisco/Vallarta
+Mexico/Sinaloa/Los Mochis,MEX/Sinaloa/Los Mochis
+Mexico/Sinaloa/Mazatlan,MEX/Sinaloa/Los Mochis
+Mexico/Chihuahua/Ciudad Juarez,MEX/Chihuahua/Ciudad Juarez

--- a/location_consolidation_mapping.csv
+++ b/location_consolidation_mapping.csv
@@ -42,7 +42,7 @@ USA/Ohio/Hamilton,USA/Ohio/Hamilton
 USA/Texas/Montgomery,USA/Texas/Montgomery
 Mexico/Sonora/San Luis Rio Colorado,MEX/Sonora/San Luis Río Colorado
 Mexico/Baja California/Tecate,MEX/Baja California/Tecate
-USA/California/Los Angeles County,USA/California/Los Angeles County
+USA/California/Los Angeles County,USA/California/Los Angeles
 USA/California/El Dorado,USA/California/El Dorado
 USA/California/Fresno,USA/California/Fresno
 USA/Alaska/Anchorage Municipality,USA/Alaska/Anchorage

--- a/readme_update.py
+++ b/readme_update.py
@@ -1,15 +1,19 @@
 """
-Updates readme based on metadata file
-#TODO: Expand file description
-#TODO: Lint and Type during PR
+This file takes an updated metadata.csv file, generates a new location summary,
+and accordingly updates the repo readme
 """
 
 import pandas as pd
 import os
 
-def generate_location_summary_table(metadata: str, out_file: str, location_combination_config: str) -> str:
+
+def generate_location_summary_table(
+    metadata: str, out_file: str, location_combination_config: str
+):
     """
-    #TODO Expand function description
+    Takes the current metadata file path, a destination file path, and a file
+    which specifies how to combine locations to generate a new markdown table
+    summarizing the number of sequences from given locations
     """
     # read file
     df = pd.read_csv(metadata)
@@ -19,36 +23,61 @@ def generate_location_summary_table(metadata: str, out_file: str, location_combi
     locations.rename(columns={"location": "Number of Sequences"}, inplace=True)
     # combine values together based on location_combination_config
     # this takes values of similar locations and combines their sequence counts
-    consolidation_config = pd.read_csv(location_combination_config, index_col=0)
+    consolidation_config = pd.read_csv(
+        location_combination_config, index_col=0)
     merged_location_data = locations.merge(
-        consolidation_config, how="left", left_index=True, right_index=True).reset_index(drop=True)
-    consolidated_location_data = merged_location_data.groupby(['corrected_location'], as_index=False).agg({'Number of Sequences':'sum'}).rename(columns={'corrected_location': "Location"}).set_index("Location").sort_index(kind="stable")
+        consolidation_config, how="left", left_index=True, right_index=True
+    ).reset_index(drop=True)
+    consolidated_location_data = (
+        merged_location_data.groupby(["corrected_location"], as_index=False)
+        .agg({"Number of Sequences": "sum"})
+        .rename(columns={"corrected_location": "Location"})
+        .set_index("Location")
+        .sort_index(kind="stable")
+    )
     # write dataframe to a a markdown table
     consolidated_location_data.to_markdown(out_file)
-    return out_file
+    return
 
-def update_and_combine_readme(metadata_md: str, readme_md: str, initial_buffer: int, ending_buffer: int):
+
+def update_and_combine_readme(
+    metadata_md: str, readme_md: str, initial_buffer: int, ending_buffer: int
+) -> None:
     """
     Takes the current readme, updates it with new table info
-    #TODO: Expand function description
     """
-    with open("new_readme.md", "w") as new_readme:    
+    with open("new_readme.md", "w") as new_readme:
+        # get the current readme header
         with open(readme_md, "r") as current_readme:
             head = current_readme.readlines()[:5]
         new_readme.writelines(head)
+        # get the new metadata table
         with open(metadata_md, "r") as location_table:
             for line in location_table:
                 new_readme.write(line)
-        # write an extra new line to separate
+        # write an extra new line to separate table from tail
         new_readme.write("\n")
+        # get the current readme tail
         with open(readme_md, "r") as current_readme:
             tail = current_readme.readlines()[ending_buffer:]
         new_readme.writelines(tail)
-if __name__=="__main__":
+    return
+
+
+if __name__ == "__main__":
     # generate new files and updated readme
-    generate_location_summary_table("metadata.csv", "metadata_location_summaries.md", "location_consolidation_mapping.csv")
-    update_and_combine_readme("metadata_location_summaries.md", "README.md", initial_buffer=5, ending_buffer=-20)
-    # rename current readme to OLD_readme, new readme to README.md
+    generate_location_summary_table(
+        "metadata.csv",
+        "metadata_location_summaries.md",
+        "location_consolidation_mapping.csv",
+    )
+    update_and_combine_readme(
+        "metadata_location_summaries.md",
+        "README.md",
+        initial_buffer=5,
+        ending_buffer=-20,
+    )
+    # rename current readme to OLD_readme,new readme to README.md
     os.rename("README.md", "OLD_README.md")
     os.rename("new_readme.md", "README.md")
     os.remove("metadata_location_summaries.md")

--- a/readme_update.py
+++ b/readme_update.py
@@ -1,0 +1,32 @@
+"""
+Updates readme based on metadata file
+"""
+
+import pandas as pd
+
+def generate_location_summary_table(metadata: str, out_file: str, location_combination_config: str) -> None:
+    """
+    Get original ReadME 
+    Generate a file based on metadata to get the summary
+    Map similar locations
+    Generate a new readme for the HCoV-19-Genomics Repo
+    Return that new ReadME
+    """
+    # read file
+    df = pd.read_csv(metadata)
+    # generate locations df
+    locations = pd.DataFrame(df.location.value_counts())
+    locations.index.rename("Location", inplace=True)
+    locations.rename(columns={"location": "Number of Sequences"}, inplace=True)
+    # combine values together based on location_combination_config
+    # this takes values of similar locations and combines their sequence counts
+    
+    # write dataframe to a str
+    #TODO: write this to a buffer so we can use it later
+    locations.to_markdown(out_file)
+    return
+
+def update_and_combine_readme(metadata_md: str, readme_md: str):
+    """
+    Takes the normal readme, updates it with new table info
+    """

--- a/readme_update.py
+++ b/readme_update.py
@@ -1,32 +1,54 @@
 """
 Updates readme based on metadata file
+#TODO: Expand file description
+#TODO: Lint and Type during PR
 """
 
 import pandas as pd
+import os
 
-def generate_location_summary_table(metadata: str, out_file: str, location_combination_config: str) -> None:
+def generate_location_summary_table(metadata: str, out_file: str, location_combination_config: str) -> str:
     """
-    Get original ReadME 
-    Generate a file based on metadata to get the summary
-    Map similar locations
-    Generate a new readme for the HCoV-19-Genomics Repo
-    Return that new ReadME
+    #TODO Expand function description
     """
     # read file
     df = pd.read_csv(metadata)
     # generate locations df
-    locations = pd.DataFrame(df.location.value_counts())
+    locations = pd.DataFrame(df.location.value_counts()).dropna()
     locations.index.rename("Location", inplace=True)
     locations.rename(columns={"location": "Number of Sequences"}, inplace=True)
     # combine values together based on location_combination_config
     # this takes values of similar locations and combines their sequence counts
-    
-    # write dataframe to a str
-    #TODO: write this to a buffer so we can use it later
-    locations.to_markdown(out_file)
-    return
+    consolidation_config = pd.read_csv(location_combination_config, index_col=0)
+    merged_location_data = locations.merge(
+        consolidation_config, how="left", left_index=True, right_index=True).reset_index(drop=True)
+    consolidated_location_data = merged_location_data.groupby(['corrected_location'], as_index=False).agg({'Number of Sequences':'sum'}).rename(columns={'corrected_location': "Location"}).set_index("Location").sort_index(kind="stable")
+    # write dataframe to a a markdown table
+    consolidated_location_data.to_markdown(out_file)
+    return out_file
 
-def update_and_combine_readme(metadata_md: str, readme_md: str):
+def update_and_combine_readme(metadata_md: str, readme_md: str, initial_buffer: int, ending_buffer: int):
     """
-    Takes the normal readme, updates it with new table info
+    Takes the current readme, updates it with new table info
+    #TODO: Expand function description
     """
+    with open("new_readme.md", "w") as new_readme:    
+        with open(readme_md, "r") as current_readme:
+            head = current_readme.readlines()[:5]
+        new_readme.writelines(head)
+        with open(metadata_md, "r") as location_table:
+            for line in location_table:
+                new_readme.write(line)
+        # write an extra new line to separate
+        new_readme.write("\n")
+        with open(readme_md, "r") as current_readme:
+            tail = current_readme.readlines()[ending_buffer:]
+        new_readme.writelines(tail)
+if __name__=="__main__":
+    # generate new files and updated readme
+    generate_location_summary_table("metadata.csv", "metadata_location_summaries.md", "location_consolidation_mapping.csv")
+    update_and_combine_readme("metadata_location_summaries.md", "README.md", initial_buffer=5, ending_buffer=-20)
+    # rename current readme to OLD_readme, new readme to README.md
+    os.rename("README.md", "OLD_README.md")
+    os.rename("new_readme.md", "README.md")
+    os.remove("metadata_location_summaries.md")


### PR DESCRIPTION
Automation to streamline readme updates - does the following:

1. Takes in current metadata.csv file and location_consolidation_mapping.csv file
2. Consolidates locations based on provided mapping and generates a markdown table via pandas
3. Writes new location sequence summary statistics to readme file

This PR would add code to this repo - albeit in the form of a pandas only dependent python script. Would close #18 if merged. 