### PR TITLE
Fixed consensus sequence concatenation

### DIFF
--- a/.github/workflows/combine-and-release.yml
+++ b/.github/workflows/combine-and-release.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
-      - name: Concatinate consensus sequences
-        run: cat consensus_sequences/*.fasta | gzip -9 > consensus_sequences.fasta.gz
+      - name: Concatenate consensus sequences
+        run: find consensus_sequences -type f -name '*.fasta' | xargs cat | gzip -9 > consensus_sequences.fasta.gz
       - name: Generate release tag
         id: tag
         run: |


### PR DESCRIPTION
With the original syntax, `ls consensus_sequences/*.fasta` was getting "Argument list too long", so the resulting `consensus_sequences.fasta.gz` file was empty. This patch fixes the command to concatenate and gzip the sequences